### PR TITLE
An error happens when removing a product from a shopping cart preventing the trigger from kicking in

### DIFF
--- a/views/js/front.js
+++ b/views/js/front.js
@@ -65,7 +65,7 @@ prestashop.on('updateCart', function(params)
                     }
                     else if (action === 'delete-from-cart')
                     {
-                        trackSmart.track('remove_from_cart', {
+                        trackSmart.process('remove_from_cart', {
                             'currency': prestashop.currency.iso_code,
                             'items': [ data ]
                         });


### PR DESCRIPTION
Error was 
```
Uncaught TypeError: trackSmart.track is not a function
    at Object.success (front.js:68)
    at u (core.js:39)
    at Object.fireWith [as resolveWith] (core.js:39)
    at S (core.js:39)
    at XMLHttpRequest.<anonymous> (core.js:39)
```